### PR TITLE
* minesweeper.el: Require dash library

### DIFF
--- a/minesweeper.el
+++ b/minesweeper.el
@@ -31,6 +31,8 @@
 
 ;;; Code:
 
+(require 'dash) ; For `-filter'
+
 (defgroup minesweeper-mode nil
   "Minesweeper settings."
   :group 'convenience


### PR DESCRIPTION
Hi,
I have tried your file and it fails because `-filter' is undefined.  It seems we might
need to require dash.el.